### PR TITLE
Remove Skillup banner

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,14 +56,6 @@
         <h1>Learning Hadoop 2</h1>
         <p class="lead book-caption">Design and implement data processing, lifecycle management and analytic workflows <br/> with the cutting edge toolbox of Hadoop 2.</p>
       </div>
-
-    <!-- packt sale -->
-    <hr/>
-      <div>          
-       <h3> <a href="https://www.packtpub.com/big-data-and-business-intelligence/learning-hadoop"> <img src="img/skillup_banner.png" class="img" alt=""> Learning Hadoop 2 is offered at a discounted price of $5 till the 8th of January 2016</a></h3>
-     </div>
-    <hr/>
-    <!-- end packt sale -->
 	<div class="row">
         <div class="col-md-6">          
 		<img src="img/cover.png" class="img-rounded" alt="Book cover"> 


### PR DESCRIPTION
Packt’s promotion has expired and we can remove the banner.
